### PR TITLE
fix: Removing `null | undefined` from T return type.

### DIFF
--- a/akita/src/filterNil.ts
+++ b/akita/src/filterNil.ts
@@ -1,9 +1,12 @@
 import { Observable } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
+// Utility type, remove types from T that are assignable to U
+type Diff<T, U> = T extends U ? never : T;
+
 /**
  * @example
  *
  * query.selectEntity(2).pipe(filterNil)
  */
-export const filterNil = <T>(source: Observable<T | undefined | null>) => source.pipe(filter((value): value is T => value !== null && typeof value !== 'undefined'));
+export const filterNil = <T>(source: Observable<T | undefined | null>) => source.pipe(filter((value): value is Diff<T, null | undefined> => value !== null && typeof value !== 'undefined'));

--- a/akita/src/filterNil.ts
+++ b/akita/src/filterNil.ts
@@ -1,8 +1,6 @@
 import { Observable } from 'rxjs';
 import { filter } from 'rxjs/operators';
-
-// Utility type, remove types from T that are assignable to U
-type Diff<T, U> = T extends U ? never : T;
+import { Diff } from './types';
 
 /**
  * @example

--- a/akita/src/types.ts
+++ b/akita/src/types.ts
@@ -55,3 +55,4 @@ export type getIDType<S> = S extends EntityState<any, infer I> ? I : never;
 
 export type ArrayFuncs = ((...a: any[]) => any)[];
 export type ReturnTypes<T extends ArrayFuncs> = { [P in keyof T]: T[P] extends (...a: any[]) => infer R ? R : never };
+export type Diff<T, U> = T extends U ? never : T;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/datorama/akita/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe:

Type fix
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #157


## What is the new behavior?
`filterNil` now removes `null | undefined` from the return values.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
